### PR TITLE
Build site before packaging into gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ site/_site
 .bundle
 .sass-cache
 Gemfile.lock
-/staging
 /site
 /jekyll
 /pkg

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 site/_site
 .bundle
+.sass-cache
 Gemfile.lock
+/staging
 /site
 /jekyll
 /pkg

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,13 @@
 source 'https://rubygems.org'
 gemspec
+
+if Dir.exist? 'jekyll/site'
+  require 'yaml'
+  config = YAML.load_file 'jekyll/site/_config.yml'
+
+  gems = []
+  gems.concat config['gems'] if config.include? 'gems'
+  gems << 'pygments.rb' if config['highlighter'] == 'pygments'
+
+  gems.each { |name| gem name }
+end

--- a/Rakefile
+++ b/Rakefile
@@ -18,17 +18,24 @@ end
 
 task :init do
   sh "git clone git://github.com/jekyll/jekyll.git jekyll" unless Dir.exist? "jekyll/.git"
+
   Dir.chdir("jekyll") do
     sh "git checkout master"
     sh "git pull origin master"
     sh "git pull origin --tags"
     sh "git checkout v#{version}"
   end
+  Bundler.with_clean_env { sh "bundle install" }
+
+  rm_rf "staging"
   rm_rf "site"
-  cp_r "jekyll/site", "site"
+  cp_r "jekyll/site", "staging"
+
+  sh "jekyll build -s staging -d site"
 end
 
 task :teardown do
+  rm_rf "staging"
   rm_rf "site"
   rm_rf "jekyll"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -27,15 +27,11 @@ task :init do
   end
   Bundler.with_clean_env { sh "bundle install" }
 
-  rm_rf "staging"
   rm_rf "site"
-  cp_r "jekyll/site", "staging"
-
-  sh "jekyll build -s staging -d site"
+  sh "jekyll build -s jekyll/site -d site"
 end
 
 task :teardown do
-  rm_rf "staging"
   rm_rf "site"
   rm_rf "jekyll"
 end

--- a/lib/jekyll-docs.rb
+++ b/lib/jekyll-docs.rb
@@ -1,6 +1,4 @@
-require 'rubygems'
 require 'jekyll'
-require 'tmpdir'
 
 module JekyllDocs
   class DocsCommand < Jekyll::Command
@@ -20,17 +18,13 @@ module JekyllDocs
       end
 
       def process(opts)
-        Dir.mktmpdir do |dest_dir|
-          options = opts.merge({
-            "serving"     => true,
-            "watch"       => false,
-            "config"      => File.expand_path("../../site/_config.yml", __FILE__),
-            "source"      => File.expand_path("../../site", __FILE__),
-            "destination" => dest_dir
-          })
-          Jekyll::Commands::Build.process(options)
-          Jekyll::Commands::Serve.process(options)
-        end
+        options = opts.merge({
+          "serving"     => true,
+          "watch"       => false,
+          "destination" => File.expand_path("../../site", __FILE__),
+          "skip_initial_build" => true
+        })
+        Jekyll::Commands::Serve.process(options)
       end
     end
   end


### PR DESCRIPTION
After cloning the Jekyll repository, it builds the documentation site and then puts that into the packaged gem, so no more time and disk space waste.

Fixes #10 :smile: