### PR TITLE
add Rubocop for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+Metrics/LineLength:
+  Exclude:
+    - jekyll-docs.gemspec
+
+Style/Documentation:
+  Enabled: false
+
+Style/FileName:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ def gem_file
 end
 
 def version
-  ENV.fetch('JEKYLL_VERSION')
+  ENV.fetch("JEKYLL_VERSION")
 end
 
 task :init do
@@ -44,7 +44,7 @@ end
 
 desc "Release #{name} v#{version}"
 task :release => :build do
-  unless `git branch` =~ /^\* master$/
+  unless `git branch` =~ %r!^\* master$!
     puts "You must be on the master branch to release!"
     exit!
   end

--- a/jekyll-docs.gemspec
+++ b/jekyll-docs.gemspec
@@ -1,19 +1,18 @@
 # coding: utf-8
 
 Gem::Specification.new do |spec|
-  spec.name          = 'jekyll-docs'
-  spec.version       = ENV.fetch('JEKYLL_VERSION')
-  spec.authors       = ['Parker Moore']
-  spec.email         = ['parkrmoore@gmail.com']
-  spec.summary       = %q{Offline usage documentation for Jekyll.}
-  spec.homepage      = 'http://jekyllrb.com'
-  spec.license       = 'MIT'
+  spec.name          = "jekyll-docs"
+  spec.version       = ENV.fetch("JEKYLL_VERSION")
+  spec.authors       = ["Parker Moore"]
+  spec.email         = ["parkrmoore@gmail.com"]
+  spec.summary       = "Offline usage documentation for Jekyll."
+  spec.homepage      = "https://jekyllrb.com"
+  spec.license       = "MIT"
 
-  spec.files         = Dir['**/*'].grep(%r{^(lib|site)/})
-  spec.require_paths = ['lib']
+  spec.files         = Dir["**/*"].grep(%r!^(lib|site)/!)
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'jekyll', ENV.fetch('JEKYLL_VERSION')
-
-  spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_dependency "jekyll", ENV.fetch("JEKYLL_VERSION")
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This PR is the result of adding `inherit_gem: jekyll: .rubocop.yml` to `.rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.