### PR TITLE
Allow FIX versions to be released, e.g. 3.6.1.1 for 3.6.1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ $ export JEKYLL_VERSION=3.1.2
 $ script/bootstrap
 $ bundle exec rake release
 ```
+
+Made a mistake? You can release another version of jekyll-docs by running
+the following:
+
+```console
+$ export JEKYLL_VERSION=3.1.2
+$ export JEKYLL_DOCS_VERSION=${JEKYLL_VERSION}.1 # Increment .1 to .2 if this is your second fix, etc.
+$ script/bootstrap
+$ bundle exec rake release
+```

--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,15 @@ def gemspec_file
 end
 
 def gem_file
-  "#{name}-#{version}.gem"
+  "#{name}-#{jekyll_docs_version}.gem"
 end
 
-def version
+def jekyll_version
   ENV.fetch("JEKYLL_VERSION")
+end
+
+def jekyll_docs_version
+  ENV.fetch("JEKYLL_DOCS_VERSION", jekyll_version)
 end
 
 task :init do
@@ -23,7 +27,7 @@ task :init do
     sh "git checkout master"
     sh "git pull origin master"
     sh "git pull origin --tags"
-    sh "git checkout v#{version}"
+    sh "git checkout v#{jekyll_version}"
   end
   Bundler.with_clean_env { sh "bundle install" }
 
@@ -42,7 +46,7 @@ end
 #
 #############################################################################
 
-desc "Release #{name} v#{version}"
+desc "Release #{name} v#{jekyll_docs_version}"
 task :release => :build do
   unless `git branch` =~ %r!^\* master$!
     puts "You must be on the master branch to release!"
@@ -52,17 +56,17 @@ task :release => :build do
     puts "We cannot proceed with uncommitted changes!"
     exit!
   end
-  sh "gem push pkg/#{name}-#{version}.gem"
+  sh "gem push pkg/#{gem_file}"
 end
 
-desc "Build #{name} v#{version} into pkg/"
+desc "Build #{name} v#{jekyll_docs_version} into pkg/"
 task :build => :init do
   mkdir_p "pkg"
   sh "gem build #{gemspec_file}"
   sh "mv #{gem_file} pkg"
 end
 
-desc "Install #{name} v#{version} into your gem folder."
+desc "Install #{name} v#{jekyll_docs_version} into your gem folder."
 task :install => :build do
   sh "gem install -l pkg/#{gem_file}"
 end

--- a/jekyll-docs.gemspec
+++ b/jekyll-docs.gemspec
@@ -1,8 +1,11 @@
 # coding: utf-8
 
+jekyll_version = ENV.fetch("JEKYLL_VERSION")
+jekyll_docs_version = ENV.fetch("JEKYLL_DOCS_VERSION", jekyll_version)
+
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-docs"
-  spec.version       = ENV.fetch("JEKYLL_DOCS_VERSION", ENV["JEKYLL_VERSION"])
+  spec.version       = jekyll_docs_version
   spec.authors       = ["Parker Moore"]
   spec.email         = ["parkrmoore@gmail.com"]
   spec.summary       = "Offline usage documentation for Jekyll."
@@ -12,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["**/*"].grep(%r!^(lib|site)/!)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", ENV.fetch("JEKYLL_VERSION")
+  spec.add_dependency "jekyll", jekyll_version
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/jekyll-docs.gemspec
+++ b/jekyll-docs.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-docs"
-  spec.version       = ENV.fetch("JEKYLL_VERSION")
+  spec.version       = ENV.fetch("JEKYLL_DOCS_VERSION", ENV["JEKYLL_VERSION"])
   spec.authors       = ["Parker Moore"]
   spec.email         = ["parkrmoore@gmail.com"]
   spec.summary       = "Offline usage documentation for Jekyll."


### PR DESCRIPTION
Set a `JEKYLL_DOCS_VERSION` to `JEKYLL_VERSION` plus a FIX suffix, like `.1`.

Instructions in the README.